### PR TITLE
Fix for matches in 5.22+.

### DIFF
--- a/lib/Test/Vars.pm
+++ b/lib/Test/Vars.pm
@@ -244,7 +244,7 @@ my $op_enteriter;
 my $op_entereval; # string eval
 my @op_svusers;
 BEGIN{
-    foreach my $op(qw(padsv padav padhv multideref)){
+    foreach my $op(qw(padsv padav padhv pp_match multideref)){
         $padops[B::opnumber($op)]++;
     }
     # blead commit 93bad3fd55489cbd split aelemfast into two ops.

--- a/t/02_no_warnings.t
+++ b/t/02_no_warnings.t
@@ -12,6 +12,7 @@ my @libs =  qw(
     Foreach
     CompileError
     ImplicitTopic
+    Regex
 );
 
 foreach my $lib(@libs) {

--- a/t/lib/Regex.pm
+++ b/t/lib/Regex.pm
@@ -1,0 +1,12 @@
+package Regex;
+
+use strict;
+use warnings;
+
+sub test {
+    my $test = shift;
+
+    return $test =~ /blah/;
+}
+
+1;


### PR DESCRIPTION
This is to account for this difference between 5.22+:
```
8  <@> leave[1 ref] vKP/REFC ->(end)
1     <0> enter ->2
2     <;> nextstate(main 1 -e:1) v:{ ->3
5     <2> sassign vKS/2 ->6
3        <$> const(IV 1) s ->4
4        <0> padsv[$a:1,2] sRM*/LVINTRO ->5
6     <;> nextstate(main 2 -e:1) v:{ ->7
7     </> match(/"1"/)[$a:1,2] v/RTIME ->8
```

and 5.20:

```
9  <@> leave[1 ref] vKP/REFC ->(end)
1     <0> enter ->2
2     <;> nextstate(main 1 -e:1) v:{ ->3
5     <2> sassign vKS/2 ->6
3        <$> const(IV 1) s ->4
4        <0> padsv[$a:1,2] sRM*/LVINTRO ->5
6     <;> nextstate(main 2 -e:1) v:{ ->7
8     </> match(/"1"/) vKS/RTIME ->9
7        <0> padsv[$a:1,2] s ->8
```

with `perl -MO=Concise -e 'my $a = 1; $a =~ /1/ ;'`